### PR TITLE
Dance bug fixes

### DIFF
--- a/src/carLogic/carLogic.ino
+++ b/src/carLogic/carLogic.ino
@@ -141,7 +141,7 @@ void handleInput(int danceID) {
  * Spins the car on the spot
  */
 void spin() {
-    rotateOnSpot(360, 50);   
+    rotateOnSpot(350, 30);   
 }
 
 /**
@@ -202,24 +202,24 @@ void shuffle(int speed) {
   const int mediumDistance = 10;
   const int longDistance = 20;
   
-  long startingPoint = leftOdometer.getDistance();
+  long startingPoint = rightOdometer.getDistance();
   bool danceIsFinished = false;
   int steps = 1;
   
   car.setSpeed(speed);
   
   while(!danceIsFinished) {
-    if ((steps == 1 || steps == 5) && (leftOdometer.getDirection() == 1) && ((car.getDistance() - startingPoint) == mediumDistance)) {
+    if ((steps == 1 || steps == 5) && (rightOdometer.getDirection() == 1) && ((car.getDistance() - startingPoint) == mediumDistance)) {
       car.setSpeed(0); 
       delay(1000);
       car.setSpeed(speed *-1); /* backwards*/
       steps++;
-    } else if ((steps == 2 || steps == 4) && (leftOdometer.getDirection() == -1) && ((car.getDistance() - startingPoint) == shortDistance)) {
+    } else if ((steps == 2 || steps == 4) && (rightOdometer.getDirection() == -1) && ((car.getDistance() - startingPoint) == shortDistance)) {
       car.setSpeed(0); 
       delay(1000);
       car.setSpeed(speed); /* forwards */
       steps++;
-    } else if ((steps == 3) && (leftOdometer.getDirection() == 1) && ((car.getDistance() - startingPoint) == longDistance)) {
+    } else if ((steps == 3) && (rightOdometer.getDirection() == 1) && ((car.getDistance() - startingPoint) == longDistance)) {
       car.setSpeed(0); 
       delay(1000);
       car.setSpeed(speed *-1);
@@ -284,6 +284,12 @@ void macarena(int speed) {
   int repeats = 0;
 
   while (repeats != 3) {
+    Serial.print("startingPoint = ");
+    Serial.print(startingPoint);
+    Serial.print(", repeats = ");
+    Serial.print(repeats);
+    Serial.print(", steps = ");
+    Serial.println(steps);
     if (steps == 1) {
       startingPoint = car.getDistance();
       car.setSpeed(speed);
@@ -303,6 +309,7 @@ void macarena(int speed) {
       delay(1000);
       rotateOnSpot(90,50);
       repeats++;
+      steps = 1;
     }
   }
   car.setSpeed(0); 

--- a/src/carLogic/carLogic.ino
+++ b/src/carLogic/carLogic.ino
@@ -93,11 +93,11 @@ void setup() {
 
 void loop() {
   server.handleClient();
-  
   /* unsigned int distance = sensor.getDistance();
     if (distance != 0 && distance < 20){ 
     car.setSpeed(0); 
     } */
+  car.update();
 }
 
 /**
@@ -201,14 +201,24 @@ void shuffle(int speed) {
   const int shortDistance = 5;
   const int mediumDistance = 10;
   const int longDistance = 20;
+
+  car.update();
   
-  long startingPoint = rightOdometer.getDistance();
+  long startingPoint = 0;//rightOdometer.getDistance();
   bool danceIsFinished = false;
   int steps = 1;
   
   car.setSpeed(speed);
   
   while(!danceIsFinished) {
+    Serial.print("mediumDistance = ");
+    Serial.print(mediumDistance);
+    Serial.print("startingPoint = ");
+    Serial.print(startingPoint);
+    Serial.print("distance = ");
+    Serial.print(car.getDistance());
+    Serial.print(", steps = ");
+    Serial.println(steps);
     if ((steps == 1 || steps == 5) && (rightOdometer.getDirection() == 1) && ((car.getDistance() - startingPoint) == mediumDistance)) {
       car.setSpeed(0); 
       delay(1000);
@@ -251,12 +261,21 @@ void shake(int speed) {
   int repeats = 0;
   
   while (repeats != 3){
+    car.update();
+    Serial.print("repeats = ");
+    Serial.print(repeats);
+    Serial.print(", startingPoint = ");
+    Serial.print(startingPoint);
+    Serial.print(", distance = ");
+    Serial.print(car.getDistance());
+    Serial.print(", steps = ");
+    Serial.println(steps);
     if (steps == 1) {
       startingPoint = car.getDistance();
       car.setAngle(-45);      
       car.setSpeed(speed * -1); /* going backwards, start of 'shake'*/
       steps++;
-    } else if ((steps == 2 || steps == 4) && (car.getDistance() - startingPoint) == -20) {
+    } else if ((steps == 2 || steps == 4) && (abs(car.getDistance() - startingPoint)) == 20) {
       changeDirection(speed); /* going forwards, left side of "V"*/
       steps++;
     } else if (steps == 3 && (car.getDistance() - startingPoint) == 0) {
@@ -307,9 +326,10 @@ void macarena(int speed) {
     } else if ((steps == 5) && (car.getDistance() - startingPoint == 0)) {
       car.setSpeed(0);
       delay(1000);
-      rotateOnSpot(90,50);
+      rotateOnSpot(90, 30);
       repeats++;
       steps = 1;
+      delay(1000);
     }
   }
   car.setSpeed(0); 

--- a/src/carLogic/carLogic.ino
+++ b/src/carLogic/carLogic.ino
@@ -141,6 +141,7 @@ void handleInput(int danceID) {
  * Spins the car on the spot
  */
 void spin() {
+    car.update();
     rotateOnSpot(350, 30);   
 }
 
@@ -201,8 +202,6 @@ void shuffle(int speed) {
   const int shortDistance = 5;
   const int mediumDistance = 10;
   const int longDistance = 20;
-
-  car.update();
   
   long startingPoint = 0;//rightOdometer.getDistance();
   bool danceIsFinished = false;
@@ -219,22 +218,22 @@ void shuffle(int speed) {
     Serial.print(car.getDistance());
     Serial.print(", steps = ");
     Serial.println(steps);
-    if ((steps == 1 || steps == 5) && (rightOdometer.getDirection() == 1) && ((car.getDistance() - startingPoint) == mediumDistance)) {
+    if ((steps == 1 || steps == 5) && (rightOdometer.getDirection() == 1) && (car.getDistance() == mediumDistance)) {
       car.setSpeed(0); 
       delay(1000);
       car.setSpeed(speed *-1); /* backwards*/
       steps++;
-    } else if ((steps == 2 || steps == 4) && (rightOdometer.getDirection() == -1) && ((car.getDistance() - startingPoint) == shortDistance)) {
+    } else if ((steps == 2 || steps == 4) && (rightOdometer.getDirection() == -1) && (car.getDistance() == shortDistance)) {
       car.setSpeed(0); 
       delay(1000);
       car.setSpeed(speed); /* forwards */
       steps++;
-    } else if ((steps == 3) && (rightOdometer.getDirection() == 1) && ((car.getDistance() - startingPoint) == longDistance)) {
+    } else if ((steps == 3) && (rightOdometer.getDirection() == 1) && (car.getDistance() == longDistance)) {
       car.setSpeed(0); 
       delay(1000);
       car.setSpeed(speed *-1);
       steps++;
-    } else if ((steps == 6) && ((car.getDistance() - startingPoint) == 0)) {
+    } else if ((steps == 6) && (car.getDistance() == 0)) {
       danceIsFinished = true;
       car.setSpeed(0);
     }
@@ -261,7 +260,7 @@ void shake(int speed) {
   int repeats = 0;
   
   while (repeats != 3){
-    car.update();
+
     Serial.print("repeats = ");
     Serial.print(repeats);
     Serial.print(", startingPoint = ");


### PR DESCRIPTION
Unnecessary instances of car.update() were removed from the dances they were used in except spin(). The now-unneeded attribute startingPoint was removed from shuffle() and shake().
The rotate on spot speed in macarena() was reduced from 50 to 30 to prevent it from over-shooting the 90 degree spin.

All dances now behave correctly individually and in random combinations.

Resolves #15, #49 